### PR TITLE
Move the out of boundary check in right place in bit reader

### DIFF
--- a/src/BinaryReader.php
+++ b/src/BinaryReader.php
@@ -114,7 +114,8 @@ class BinaryReader
     }
 
     /**
-     * @ return bool
+     * @param int $length
+     * @return bool
      */
     public function canReadBytes($length = 0)
     {

--- a/src/Type/Bit.php
+++ b/src/Type/Bit.php
@@ -28,10 +28,6 @@ class Bit implements TypeInterface
             throw new InvalidDataException('The length parameter must be an integer');
         }
 
-        if (!$br->canReadBytes($length / 8)) {
-            throw new \OutOfBoundsException('Cannot read bits, it exceeds the boundary of the file');
-        }
-
         $bitmask = new BitMask();
         $result = 0;
         $bits = $length;
@@ -52,6 +48,10 @@ class Bit implements TypeInterface
 
                 return $br->getNextByte() >> $shift;
             }
+        }
+
+        if (!$br->canReadBytes($length / 8)) {
+            throw new \OutOfBoundsException('Cannot read bits, it exceeds the boundary of the file');
         }
 
         if ($bits >= 8) {

--- a/test/Type/BitTest.php
+++ b/test/Type/BitTest.php
@@ -35,6 +35,14 @@ class BitTest extends AbstractTestCase
         $this->assertEquals(0, $brLittle->readUBits(4));
         $this->assertEquals(0, $brBig->readUBits(2));
         $this->assertEquals(0, $brLittle->readUBits(2));
+
+        $brBig->readUBits(80);
+        $brLittle->readUBits(80);
+
+        $this->assertEquals(0xF, $brBig->readUBits(4));
+        $this->assertEquals(0xF, $brLittle->readUBits(4));
+        $this->assertEquals(3, $brBig->readUBits(2));
+        $this->assertEquals(3, $brLittle->readUBits(2));
     }
 
     /**
@@ -99,5 +107,31 @@ class BitTest extends AbstractTestCase
     public function testExceptionInvalidBitCountLittleEndian($brBig, $brLittle)
     {
         $brLittle->readBits('foo');
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     * @dataProvider binaryReaders
+     */
+    public function testExceptionBitsOnLastBitsBigEndian($brBig, $brLittle)
+    {
+        $brBig->setPosition(15);
+        $brBig->readBits(4);
+        $brBig->readBits(2);
+        $brBig->readBits(2);
+        $brBig->readBits(1);
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     * @dataProvider binaryReaders
+     */
+    public function testExceptionBitsOnLastBitsLittleEndian($brBig, $brLittle)
+    {
+        $brLittle->setPosition(15);
+        $brLittle->readBits(4);
+        $brLittle->readBits(2);
+        $brLittle->readBits(2);
+        $brLittle->readBits(1);
     }
 }


### PR DESCRIPTION
In case I try to read last byte of data source by bits batches, the OutOfBoundsException is thrown. Although there is still a unread bits. For example:
```php
    $reader = new BinaryReader('1');
    $reader->readUBits(1);
    $reader->readUBits(5); // exception will be thrown
```
This patch fixes the problem.