### PR TITLE
add .gitattributes to export-ignore non source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+/test export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/README.md export-ignore


### PR DESCRIPTION
Add a `.gitattributes` file so non source files aren't included in a project's vendor directory such as large test file data.