### PR TITLE
Feature/double-reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Methods
 
 **readSingle()** returns a 4-bytes floating-point
 
+**readDouble()** returns a 8-bytes signed double
+
 **readUBits($length)** returns a variable length of bits (unsigned)
 
 **readBits($length)** returns a variable length of bits (signed)

--- a/src/BinaryReader.php
+++ b/src/BinaryReader.php
@@ -5,6 +5,7 @@ namespace PhpBinaryReader;
 use PhpBinaryReader\Exception\InvalidDataException;
 use PhpBinaryReader\Type\Bit;
 use PhpBinaryReader\Type\Byte;
+use PhpBinaryReader\Type\Double;
 use PhpBinaryReader\Type\Int8;
 use PhpBinaryReader\Type\Int16;
 use PhpBinaryReader\Type\Int32;
@@ -90,6 +91,11 @@ class BinaryReader
     private $singleReader;
 
     /**
+     * @var \PhpBinaryReader\Type\Double
+     */
+    private $doubleReader;
+
+    /**
      * @param  string|resource           $input
      * @param  int|string                $endian
      * @throws \InvalidArgumentException
@@ -117,6 +123,7 @@ class BinaryReader
         $this->int32Reader = new Int32();
         $this->int64Reader = new Int64();
         $this->singleReader = new Single();
+        $this->doubleReader = new Double();
     }
 
     /**
@@ -242,6 +249,11 @@ class BinaryReader
     public function readSingle()
     {
         return $this->singleReader->read($this);
+    }
+
+    public function readDouble()
+    {
+        return $this->doubleReader->read($this);
     }
 
     /**
@@ -472,6 +484,14 @@ class BinaryReader
     public function getSingleReader()
     {
         return $this->singleReader;
+    }
+
+    /**
+     * @return \PhpBinaryReader\Type\Double
+     */
+    public function getDoubleReader()
+    {
+        return $this->doubleReader;
     }
 
     /**

--- a/src/Type/Double.php
+++ b/src/Type/Double.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PhpBinaryReader\Type;
+
+use PhpBinaryReader\BinaryReader;
+use PhpBinaryReader\Type\TypeInterface;
+
+class Double implements TypeInterface
+{
+
+    /**
+     * Returns a 8-bytes double
+     *
+     * @param \PhpBinaryReader\BinaryReader $br
+     * @param null $length
+     *
+     * @return float
+     * @throws \OutOfBoundsException
+     */
+    public function read(BinaryReader &$br, $length = null)
+    {
+        if (!$br->canReadBytes(8)) {
+            throw new \OutOfBoundsException('Cannot read 8-bytes double, it exceeds the boundary of the file');
+        }
+
+        $segment = $br->readFromHandle(8);
+        if ($br->getCurrentBit() !== 0) {
+            $data = unpack('N', $segment)[1];
+            $data = $this->bitReader($br, $data);
+            $endian = $br->getMachineByteOrder() === $br->getEndian() ? 'N' : 'V';
+            $segment = pack($endian, $data);
+        } elseif ($br->getMachineByteOrder() !== $br->getEndian()) {
+            $segment = strrev($segment);
+        }
+
+        $value = unpack('d', $segment)[1];
+        return $value;
+    }
+
+    /**
+     * @param \PhpBinaryReader\BinaryReader $br
+     * @param int $data
+     *
+     * @return int
+     */
+    private function bitReader(BinaryReader $br, $data)
+    {
+        $mask = 0x7FFFFFFFFFFFFFFF >> ($br->getCurrentBit() - 1);
+        $value = (($data >> (8 - $br->getCurrentBit())) & $mask) | ($br->getNextByte() << (56 + $br->getCurrentBit()));
+        $br->setNextByte($data & 0xFF);
+        return $value;
+    }
+}

--- a/test/BinaryReaderTest.php
+++ b/test/BinaryReaderTest.php
@@ -148,6 +148,24 @@ class BinaryReaderTest extends AbstractTestCase
     }
 
     /**
+     * @param \PhpBinaryReader\BinaryReader $brBig
+     * @param \PhpBinaryReader\BinaryReader $brLittle
+     *
+     * @dataProvider binaryReaders
+     */
+    public function testDouble(BinaryReader $brBig, BinaryReader $brLittle)
+    {
+        $brBig->setPosition(16);
+        $brLittle->setPosition(16);
+
+        $this->assertEquals(1.0, $brBig->readDouble());
+        $this->assertEquals(1.0, $brLittle->readDouble());
+
+        $this->assertEquals(-1.0, $brBig->readDouble());
+        $this->assertEquals(-1.0, $brLittle->readDouble());
+    }
+
+    /**
      * @dataProvider binaryReaders
      */
     public function testAlign($brBig, $brLittle)
@@ -340,5 +358,6 @@ class BinaryReaderTest extends AbstractTestCase
         $this->assertInstanceOf('\PhpBinaryReader\Type\Int8', $brBig->getInt8Reader());
         $this->assertInstanceOf('\PhpBinaryReader\Type\Str', $brBig->getStringReader());
         $this->assertInstanceOf('\PhpBinaryReader\Type\Single', $brBig->getSingleReader());
+        $this->assertInstanceOf('\PhpBinaryReader\Type\Double', $brBig->getDoubleReader());
     }
 }


### PR DESCRIPTION
Add support for reading double data types

A new functionality has been introduced in the BinaryReader class to support reading double data types from binary files. A new 'Double' class has also been created in the Type namespace to handle the actual reading and conversion of the double data types. Accompanying unit tests have been updated to ensure the proper functionality of these new features.